### PR TITLE
IAR OOB fix

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -24,10 +24,11 @@
 
 void print_stats()
 {
-    mbed_stats_socket_t stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT] = {0};
+    mbed_stats_socket_t stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];
     static int num = 0;
     int count;
     
+    memset(&stats[0], 0, sizeof(mbed_stats_socket_t) * MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT);
     printf("%-15s%-15s%-15s%-15s%-15s%-15s%-15s\n", "Num", "ID", "State", "Proto", "Sent", "Recv", "Time");
     while (1) {
 


### PR DESCRIPTION
Internal error: [Front end]: assertion failed at: "..\..\Translator\compiler_core\src\parser\edg\decl_inits.c", line 2031

IAR internal build fails when array is initialized during declaration.

Resolves: https://github.com/ARMmbed/mbed-os-example-socket-stats/issues/2