### PR TITLE
[OoB 5.13] Arm Compiler 5 is not default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This example demonstrates how you can collect statistics from network sockets. Y
 
 ### Building
 
-Invoke `mbed compile`, and specify the name of your platform and your favorite toolchain (`GCC_ARM`, `ARM`, `IAR`). For example, for the Arm Compiler 5:
+Invoke `mbed compile`, and specify the name of your platform and your favorite toolchain (`GCC_ARM`, `ARM`, `IAR`). For example, for the Arm Compiler 6:
 
 ```
 mbed compile -t <toolchain> -m <target>


### PR DESCRIPTION
In the Building section in README.md, Arm Compiler 5 is mentioned. However, ARM Compiler 6 is default from Mbed OS 5.12.
https://github.com/ARMmbed/mbed-os/pull/9888