### PR TITLE
Replace string-based API with SocketAddress-based ones

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -100,12 +100,13 @@ int main()
     }
 
     // Show the network address
-    const char *ip = net->get_ip_address();
-    const char *netmask = net->get_netmask();
-    const char *gateway = net->get_gateway();
-    printf("IP address: %s\n", ip ? ip : "None");
-    printf("Netmask: %s\n", netmask ? netmask : "None");
-    printf("Gateway: %s\n", gateway ? gateway : "None");
+    SocketAddress a;
+    net->get_ip_address(&a);
+    printf("IP address: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
+    net->get_netmask(&a);
+    printf("Netmask: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
+    net->get_gateway(&a);
+    printf("Gateway: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
 
     Thread *thread = new Thread(osPriorityNormal1, 2048);
     thread->start(print_stats);
@@ -128,7 +129,13 @@ int main()
     char *buffer = new char[256];
     char *p = buffer;
 
-    result = socket.connect("api.ipify.org", 80);
+    result = NetworkInterface::get_default_instance()->gethostbyname("api.ipify.org", &a);
+    if (result != NSAPI_ERROR_OK) {
+        printf("Error! DNS resolution failed with %d\n", result);
+        goto DISCONNECT;
+    }
+    a.set_port(80);
+    result = socket.connect(a);
     if (result != 0) {
         stdio_mutex.lock();
         printf("Error! socket.connect() returned: %d\n", result);

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#cf4f12a123c05fcae83fc56d76442015cb8a39e9
+https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7


### PR DESCRIPTION
String-based APIs were marked deprecated and replaced by `SocketAddress`-based APIs in https://github.com/ARMmbed/mbed-os/pull/11914.
This PR switches the example to the new API and removes the deprecated one.
To get this compile I updated `mbed-os.lib` version to 5.15.