### PR TITLE
Make compatible with Minimal-printf

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -33,40 +33,39 @@ void print_stats()
     int count;
 
     memset(&stats[0], 0, sizeof(mbed_stats_socket_t) * MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT);
-    printf("%-15s%-15s%-15s%-15s%-15s%-15s%-15s\n", "Num", "ID", "State", "Proto", "Sent", "Recv", "Time");
     while (COMPLETED_FLAG != threadFlag.get()) {
         count = SocketStats::mbed_stats_socket_get_each(&stats[0], MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT);
         for (int i = 0; i < count; i++) {
             stdio_mutex.lock();
-            printf("\n%-15d", num);
-            printf("%-15p", stats[i].reference_id);
+            printf("Num: %d", num);
+            printf(" ID: %p", stats[i].reference_id);
 
             switch (stats[i].state) {
                 case SOCK_CLOSED:
-                    printf("%-15s", "Closed");
+                    printf(" State: Closed");
                     break;
                 case SOCK_OPEN:
-                    printf("%-15s", "Open");
+                    printf(" State: Open");
                     break;
                 case SOCK_CONNECTED:
-                    printf("%-15s", "Connected");
+                    printf(" State: Connected");
                     break;
                 case SOCK_LISTEN:
-                    printf("%-15s", "Listen");
+                    printf(" State: Listen");
                     break;
                 default:
-                    printf("%-15s", "Error");
+                    printf(" State: Error");
                     break;
             }
 
             if (NSAPI_TCP == stats[i].proto) {
-                printf("%-15s", "TCP");
+                printf(" Proto: TCP");
             } else {
-                printf("%-15s", "UDP");
+                printf(" Proto: UDP");
             }
-            printf("%-15d", stats[i].sent_bytes);
-            printf("%-15d", stats[i].recv_bytes);
-            printf("%-15lld\n", stats[i].last_change_tick);
+            printf(" Sent: %d", stats[i].sent_bytes);
+            printf(" Recv: %d", stats[i].recv_bytes);
+            printf(" Time: %lld\n", stats[i].last_change_tick);
             stdio_mutex.unlock();
         }
         num++;

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,8 +3,12 @@
 Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log. 
 
 To run the test, use following command after you build the example:
+```bash
+$ mbedhtrun -d <MOUNT_POINT> -p <SERIAL_PORT> -m <TARGET> -f ./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-socket-stats.bin --compare-log tests/socket-stats.log
 ```
-mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\socket-stats.bin --compare-log tests\socket-stats.log
+For example:
+```bash
+$ mbedhtrun -d /media/user01/DAPLINK -p /dev/ttyACM0 -m K64F -f ./BUILD/K64F/GCC_ARM/mbed-os-example-socket-stats.bin --compare-log tests/socket-stats.log
 ```
 
 

--- a/tests/socket-stats.log
+++ b/tests/socket-stats.log
@@ -4,20 +4,19 @@ Mbed OS version:
 IP address: (?:[0-9]{1,3}\.){3}[0-9]{1,3}
 Netmask: (?:[0-9]{1,3}\.){3}[0-9]{1,3}
 Gateway: (?:[0-9]{1,3}\.){3}[0-9]{1,3}
-Num\s+ID\s+State\s+Proto\s+Sent\s+Recv\s+Time
 
-\d+\s+(0x)?[0-9a-fA-F]+\s+Open\s+TCP\s+\d+\s+\d+\s+\d+
-\d+\s+(0x)?[0-9a-fA-F]+\s+Closed\s+UDP\s+\d+\s+\d+\s+\d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Open Proto: TCP Sent: \d+ Recv: \d+ Time: \d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Closed Proto: UDP Sent: \d+ Recv: \d+ Time: \d+
 sent \d+ \[GET \/ HTTP\/\d.\d\]
 
-\d+\s+(0x)?[0-9a-fA-F]+\s+Connected\s+TCP\s+\d+\s+\d+\s+\d+
-\d+\s+(0x)?[0-9a-fA-F]+\s+Closed\s+UDP\s+\d+\s+\d+\s+\d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Connected Proto: TCP Sent: \d+ Recv: \d+ Time: \d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Closed Proto: UDP Sent: \d+ Recv: \d+ Time: \d+
 recv \d+ \[HTTP\/\d.\d \d+ OK\]
 
-\d+\s+(0x)?[0-9a-fA-F]+\s+Connected\s+TCP\s+\d+\s+\d+\s+\d+
-\d+\s+(0x)?[0-9a-fA-F]+\s+Closed\s+UDP\s+\d+\s+\d+\s+\d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Connected Proto: TCP Sent: \d+ Recv: \d+ Time: \d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Closed Proto: UDP Sent: \d+ Recv: \d+ Time: \d+
 External IP address: (?:[0-9]{1,3}\.){3}[0-9]{1,3}
 
-\d+\s+(0x)?[0-9a-fA-F]+\s+Connected\s+TCP\s+\d+\s+\d+\s+\d+
-\d+\s+(0x)?[0-9a-fA-F]+\s+Closed\s+UDP\s+\d+\s+\d+\s+\d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Connected Proto: TCP Sent: \d+ Recv: \d+ Time: \d+
+Num: \d+ ID: (0x)?[0-9a-fA-F]+ State: Closed Proto: UDP Sent: \d+ Recv: \d+ Time: \d+
 Done


### PR DESCRIPTION
Remove flags and width format sub-specifiers on `printf()` calls as
Minimal-printf does not support them. This commit ensures that the
output when built with Minimal-printf is legible and similar to the
output when using the standard library.