### PR TITLE
Fix IAR build failure

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -28,7 +28,7 @@ EventFlags threadFlag;
 
 void print_socket_stats()
 {
-    mbed_stats_socket_t stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT] = {0};
+    static mbed_stats_socket_t stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];
     int iteration = 0;
 
     while (COMPLETED_FLAG != threadFlag.get()) {


### PR DESCRIPTION
Fixes https://github.com/ARMmbed/mbed-os/issues/12455.

Set local `stats` array to static to fix issue. It also avoids putting large objects on the stack.