### PR TITLE
Update mbed-os.lib to release 5.15.1

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#e642a7d8b3609a7c903e042cd772f00a5d299088


### PR DESCRIPTION
Updated mbed-os.lib to release 5.15.1

### Reviewers <!-- Optional -->
@evedon 